### PR TITLE
(Refactoring) Introduce `SpanBehavior` Enum

### DIFF
--- a/examples/wipac_tracing/evented_examples.py
+++ b/examples/wipac_tracing/evented_examples.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 import time
+from typing import Generator
 
 import coloredlogs  # type: ignore[import]
 

--- a/examples/wipac_tracing/evented_with_overriding_span_examples.py
+++ b/examples/wipac_tracing/evented_with_overriding_span_examples.py
@@ -15,10 +15,11 @@ from wipac_telemetry import tracing_tools  # noqa: E402 # pylint: disable=C0413,
 from wipac_telemetry.tracing_tools import (  # noqa: E402 # pylint: disable=C0413
     OptSpan,
     Span,
+    SpanBehavior,
 )
 
 
-@tracing_tools.spanned(inject=True)
+@tracing_tools.spanned(behavior=SpanBehavior.INDEPENDENT_SPAN)
 def the_one_that_returns_a_span(span: OptSpan = None) -> Span:
     """Use Span-injection to set the span."""
     logging.info("the_one_that_returns_a_span()")

--- a/examples/wipac_tracing/span_injection_examples.py
+++ b/examples/wipac_tracing/span_injection_examples.py
@@ -27,14 +27,14 @@ class DemoPitfallsClass:
     ##################
 
     # NOT OKAY
-    @tracing_tools.spanned(inject=True)
+    @tracing_tools.spanned(behavior=tracing_tools.SpanBehavior.INDEPENDENT_SPAN)
     def invalid_start_span(self, span: tracing_tools.OptSpan = None) -> None:
         """ERROR: making an instance-originated span is not supported, will break if called."""
         self.span = span
 
     # USE THIS INSTEAD
     @staticmethod
-    @tracing_tools.spanned(inject=True)
+    @tracing_tools.spanned(behavior=tracing_tools.SpanBehavior.INDEPENDENT_SPAN)
     def static_start_span(
         inst: "DemoPitfallsClass", span: tracing_tools.OptSpan = None
     ) -> None:
@@ -87,7 +87,9 @@ class ExternalClass:
     #         self.span.end()
 
 
-@tracing_tools.spanned(inject=True, attributes={"a": 1})
+@tracing_tools.spanned(
+    behavior=tracing_tools.SpanBehavior.INDEPENDENT_SPAN, attributes={"a": 1}
+)
 def injected_span_pass_to_instance(span: tracing_tools.OptSpan = None) -> ExternalClass:
     """Inject a span then pass onto an instance."""
     if not span:

--- a/examples/wipac_tracing/span_linking_examples.py
+++ b/examples/wipac_tracing/span_linking_examples.py
@@ -19,6 +19,7 @@ from wipac_telemetry.tracing_tools import (  # noqa: E402 # pylint: disable=C041
     Link,
     OptSpan,
     Span,
+    SpanBehavior,
     make_link,
 )
 
@@ -64,7 +65,7 @@ class Client:
     def __init__(self, server: Server) -> None:
         self.server = server
 
-    @tracing_tools.spanned(inject=True, these=["urgent"])
+    @tracing_tools.spanned(behavior=SpanBehavior.INDEPENDENT_SPAN, these=["urgent"])
     def send_1_with_injection(
         self, message: str, span: OptSpan = None, urgent: bool = False, delay: int = 0
     ) -> None:

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -15,7 +15,7 @@ from opentelemetry.sdk.trace.export import (  # type: ignore[import]
 from . import propagations  # noqa
 from .config import CONFIG
 from .events import evented  # noqa
-from .spans import make_link, spanned  # noqa
+from .spans import SpanBehavior, make_link, spanned  # noqa
 from .utils import Link, OptSpan, Span, SpanKind, get_current_span  # noqa
 
 __all__ = [
@@ -28,6 +28,7 @@ __all__ = [
     "Span",
     "SpanKind",
     "get_current_span",
+    "SpanBehavior",
 ]
 
 # Config SDK ###########################################################################

--- a/wipac_telemetry/tracing_tools/spans.py
+++ b/wipac_telemetry/tracing_tools/spans.py
@@ -78,7 +78,8 @@ def spanned(
                 - `"CONSUMER"`/`SpanKind.CONSUMER` - spanned function makes outgoing cross-service messages
                 - `"PRODUCER"`/`SpanKind.PRODUCER` - spanned function handles incoming cross-service messages
 
-    Raises a `ValueError` when attempting to self-link the injected span.
+    Raises a `ValueError` when attempting to self-link the independent/injected span
+    Raises a `InvalidSpanBehaviorValue` when an invalid `behavior` value is attempted
     """
     # TODO - what is `is_remote`?
     def inner_function(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/wipac_telemetry/tracing_tools/spans.py
+++ b/wipac_telemetry/tracing_tools/spans.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import inspect
+from enum import Enum, auto
 from functools import wraps
 from typing import Any, Callable, List, Optional, Tuple, Union
 
@@ -23,12 +24,24 @@ from .utils import (
 )
 
 
+class SpanBehavior(Enum):
+    """Enum for indicating type of span for manual use."""
+
+    AUTO_CURRENT_SPAN = auto()
+    MANUAL_CURRENT_SPAN = auto()
+    INDEPENDENT_SPAN = auto()
+
+
+class InvalidSpanBehaviorValue(ValueError):
+    """Raise when an invalid SpanBehvior value is attempted."""
+
+
 def spanned(
     name: Optional[str] = None,
     attributes: types.Attributes = None,
     all_args: bool = False,
     these: Optional[List[str]] = None,
-    inject: bool = False,
+    behavior: SpanBehavior = SpanBehavior.AUTO_CURRENT_SPAN,
     links: Optional[List[str]] = None,
     kind: Union[SpanKind, str] = SpanKind.INTERNAL,
 ) -> Callable[..., Any]:
@@ -41,8 +54,20 @@ def spanned(
         attributes -- a dict of attributes to add to span
         all_args -- whether to auto-add all the function-arguments as attributes
         these -- a whitelist of function-arguments and/or `self.*`-variables to add as attributes
-        inject -- whether to inject the span instance into the function (as `span`).
-                  (`inject=True` won't set as current span nor automatically exit once function is done.)
+        behavior -- indicate what type of span behavior is wanted:
+                    - `SpanBehavior.AUTO_CURRENT_SPAN`
+                        + start span as the current span (accessible via `get_current_span()`)
+                        + automatically exit after function returns
+                        + default value
+                    - `SpanBehavior.MANUAL_CURRENT_SPAN`
+                        + start span as the current span (accessible via `get_current_span()`)
+                        + requires a call to `__exit__()`
+                        + can be persisted between independent functions
+                    - `SpanBehavior.INDEPENDENT_SPAN`
+                        + start span NOT as the current span
+                        + injects span instance into the function/method's argument list as `span`
+                        + requires a call to `span.end()`
+                        + can be persisted between independent functions
         links -- a list of variable names of `Link` instances (span-links) - useful for cross-process tracing
         kind -- either a `SpanKind` enum value or an equivalent str
                 - `"INTERNAL"`/`SpanKind.INTERNAL` - (default) normal, in-application spans
@@ -61,8 +86,10 @@ def spanned(
             span_name = name if name else func.__qualname__  # Ex: MyClass.method
             tracer_name = inspect.getfile(func)  # Ex: /path/to/source_file.py
 
-            if inject and links and "span" in links:
-                raise ValueError("Cannot self-link the injected span: `span`")
+            if behavior == SpanBehavior.INDEPENDENT_SPAN and links and "span" in links:
+                raise ValueError(
+                    "Cannot self-link the independent/injected span: `span`"
+                )
 
             func_inspect = FunctionInspection(func, args, kwargs)
 
@@ -97,38 +124,62 @@ def spanned(
             LOGGER.debug("Spanned Function")
             tracer, span_name, setup_kwargs = setup(args, kwargs)
 
-            if inject:
-                kwargs["span"] = tracer.start_span(span_name, **setup_kwargs)
-                return func(*args, **kwargs)
-            else:
+            if behavior == SpanBehavior.AUTO_CURRENT_SPAN:
                 with tracer.start_as_current_span(span_name, **setup_kwargs):
                     return func(*args, **kwargs)
+            elif behavior == SpanBehavior.INDEPENDENT_SPAN:
+                kwargs["span"] = tracer.start_span(span_name, **setup_kwargs)
+                return func(*args, **kwargs)
+            elif behavior == SpanBehavior.MANUAL_CURRENT_SPAN:
+                tracer.start_as_current_span(span_name, **setup_kwargs).__enter__()
+                return func(*args, **kwargs)
+            else:
+                raise InvalidSpanBehaviorValue(behavior)
 
         @wraps(func)
         def gen_wrapper(*args: Any, **kwargs: Any) -> Any:
             LOGGER.debug("Spanned Generator Function")
             tracer, span_name, setup_kwargs = setup(args, kwargs)
 
-            if inject:
+            if behavior == SpanBehavior.INDEPENDENT_SPAN:
                 kwargs["span"] = tracer.start_span(span_name, **setup_kwargs)
-                for val in func(*args, **kwargs):
-                    yield val
+
             else:
                 with tracer.start_as_current_span(span_name, **setup_kwargs):
                     for val in func(*args, **kwargs):
                         yield val
+
+            if behavior == SpanBehavior.AUTO_CURRENT_SPAN:
+                with tracer.start_as_current_span(span_name, **setup_kwargs):
+                    for val in func(*args, **kwargs):
+                        yield val
+            elif behavior == SpanBehavior.INDEPENDENT_SPAN:
+                kwargs["span"] = tracer.start_span(span_name, **setup_kwargs)
+                for val in func(*args, **kwargs):
+                    yield val
+            elif behavior == SpanBehavior.MANUAL_CURRENT_SPAN:
+                tracer.start_as_current_span(span_name, **setup_kwargs).__enter__()
+                for val in func(*args, **kwargs):
+                    yield val
+            else:
+                raise InvalidSpanBehaviorValue(behavior)
 
         @wraps(func)
         async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             LOGGER.debug("Spanned Async Function")
             tracer, span_name, setup_kwargs = setup(args, kwargs)
 
-            if inject:
-                kwargs["span"] = tracer.start_span(span_name, **setup_kwargs)
-                return await func(*args, **kwargs)
-            else:
+            if behavior == SpanBehavior.AUTO_CURRENT_SPAN:
                 with tracer.start_as_current_span(span_name, **setup_kwargs):
                     return await func(*args, **kwargs)
+            elif behavior == SpanBehavior.INDEPENDENT_SPAN:
+                kwargs["span"] = tracer.start_span(span_name, **setup_kwargs)
+                return await func(*args, **kwargs)
+            elif behavior == SpanBehavior.MANUAL_CURRENT_SPAN:
+                tracer.start_as_current_span(span_name, **setup_kwargs).__enter__()
+                return await func(*args, **kwargs)
+            else:
+                raise InvalidSpanBehaviorValue(behavior)
 
         if asyncio.iscoroutinefunction(func):
             return async_wrapper


### PR DESCRIPTION
"inject" was not descriptive enough, plus there's another thing called span injection that deals with http things.

`inject=True` is now `behavior=SpanBehavior.INDEPENDENT_SPAN`