### PR TITLE
Parent-Child Tracing for Multi-Threading, Multi-Processing, and Distributed Client-Server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
           - checkout
           - run: |
               pip install -r requirements.txt
-              for f in examples/wipac_tracing/*.py; do python "$f"; done
+              ./examples/wipac_tracing/run_all_examples.sh
 
 workflows:
     version: 2

--- a/examples/wipac_tracing/run_all_examples.sh
+++ b/examples/wipac_tracing/run_all_examples.sh
@@ -1,0 +1,9 @@
+# Run all the example python files
+
+
+files=`find examples/wipac_tracing/ -name '*.py' -a ! -name 'span_client_server_http.py'`
+for f in $files; do python "$f"; done
+
+python examples/wipac_tracing/span_client_server_http.py server &
+python examples/wipac_tracing/span_client_server_http.py client &
+wait

--- a/examples/wipac_tracing/span_client_server_http.py
+++ b/examples/wipac_tracing/span_client_server_http.py
@@ -1,0 +1,123 @@
+"""Examples for spanned() decorator with http-based client/server tracing."""
+
+
+import http.client
+import logging
+import os
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import coloredlogs  # type: ignore[import]
+
+if "examples" not in os.listdir():
+    raise RuntimeError("Script needs to be ran from root of repository.")
+
+sys.path.append(".")
+import wipac_telemetry.tracing_tools as wtt  # noqa: E402 # pylint: disable=C0413,E0401
+
+ADDRESS = "127.0.0.1"
+PORT = 2000
+
+########################################################################################
+
+
+@wtt.spanned(kind=wtt.SpanKind.CLIENT)
+def client() -> None:
+    """Run HTTP client."""
+    logging.info("Example HTTP Client with 'kind=SpanKind.CLIENT'")
+
+    logging.debug("http client is starting...")
+    time.sleep(0.5)
+
+    conn = http.client.HTTPConnection(ADDRESS, PORT)  # create a connection
+    logging.debug("http client is running...")
+    time.sleep(0.5)
+
+    for msg in ["ham", "cheese", "bacon", "nails"]:
+        wtt.add_event(
+            "Outgoing Server Request",
+            {"message": msg, "address": ADDRESS, "port": PORT},
+        )
+        conn.request("GET", msg, headers=wtt.inject_span_carrier())
+
+        # get response from server
+        rsp = conn.getresponse()
+        data_received = str(rsp.read())
+
+        wtt.add_event(
+            "Incoming Server Response",
+            {"message": data_received, "status": rsp.status, "reason": rsp.reason},
+        )
+
+        # print server response and data
+        logging.debug(rsp.status)
+        logging.debug(rsp.reason)
+        logging.debug(data_received)
+
+        time.sleep(1)
+
+    conn.close()
+
+
+########################################################################################
+
+
+class HTTPRequestHandler(BaseHTTPRequestHandler):
+    """Custom HTTPRequestHandler class."""
+
+    @wtt.spanned(kind=wtt.SpanKind.SERVER, carrier="self.headers")
+    def do_GET(self) -> None:  # pylint: disable=invalid-name
+        """Handle GET command."""
+        logging.info("Example HTTP Server Handler with 'kind=SpanKind.SERVER'")
+
+        all_responses = {
+            "ham": "ham sandwich!",
+            "cheese": "cheese sandwich!",
+            "bacon": "BLT!",
+        }
+
+        if self.path in all_responses:
+            self.send_response(200)
+
+            # send header first
+            self.send_header("Content-type", "text-html")
+            self.end_headers()
+
+            # send file content to client
+            self.wfile.write(all_responses[self.path].encode())
+
+        else:
+            self.send_error(404, "Ingredient not found!")
+
+            logging.critical("Server shutting down (to end testing)")
+            sys.exit(0)
+
+
+def server() -> None:
+    """Run HTTP server."""
+    logging.info("Example HTTP Server Application")
+
+    logging.debug("http server is starting...")
+    time.sleep(0.5)
+
+    server_address = (ADDRESS, PORT)
+    httpd = HTTPServer(server_address, HTTPRequestHandler)
+
+    logging.debug("http server is running...")
+    time.sleep(0.5)
+
+    httpd.serve_forever()
+
+
+########################################################################################
+
+
+if __name__ == "__main__":
+    coloredlogs.install(level="DEBUG")
+
+    try:
+        {"client": client, "server": server}[sys.argv[1]]()
+    except (IndexError, KeyError):
+        logging.debug("enter either 'client' or 'server'")
+        sys.exit(1)

--- a/examples/wipac_tracing/span_multithreaded.py
+++ b/examples/wipac_tracing/span_multithreaded.py
@@ -74,5 +74,5 @@ if __name__ == "__main__":
     logging.warning("EXAMPLE #1 - No carrier")
     example_1_no_carrier(3)
 
-    logging.warning("EXAMPLE #1 - With carrier")
+    logging.warning("EXAMPLE #2 - With carrier")
     example_2_w_carrier(3)

--- a/examples/wipac_tracing/span_multithreaded.py
+++ b/examples/wipac_tracing/span_multithreaded.py
@@ -1,0 +1,78 @@
+"""Example script for the spanned() decorator."""
+
+
+import logging
+import os
+import sys
+import time
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from typing import Any, Dict, List
+
+import coloredlogs  # type: ignore[import]
+
+if "examples" not in os.listdir():
+    raise RuntimeError("Script needs to be ran from root of repository.")
+
+sys.path.append(".")
+import wipac_telemetry.tracing_tools as wtt  # noqa: E402 # pylint: disable=C0413,E0401
+
+########################################################################################
+
+
+@wtt.spanned()
+def example_1_no_carrier(n_threads: int) -> None:
+    """Run multiple independent threads, without a common carrier."""
+
+    @wtt.spanned(all_args=True)
+    def thread_work(worker: int) -> int:
+        """Do thread's work."""
+        time.sleep(1)
+        return worker
+
+    futures: List[Future] = []  # type: ignore[type-arg]
+    with ThreadPoolExecutor() as pool:
+        for i in range(n_threads):
+            futures.append(pool.submit(thread_work, i))
+
+    for worker in as_completed(futures):
+        ret = worker.result()
+        print(f"Returned Worker #{ret}")
+
+
+########################################################################################
+
+
+@wtt.spanned()
+def example_2_w_carrier(n_threads: int) -> None:
+    """Run multiple independent threads, with a common carrier."""
+
+    @wtt.spanned(all_args=True, carrier="carrier")
+    def thread_work(worker: int, carrier: Dict[str, Any]) -> int:
+        """Do thread's work."""
+        print(carrier)
+        time.sleep(1)
+        return worker
+
+    futures: List[Future] = []  # type: ignore[type-arg]
+    with ThreadPoolExecutor() as pool:
+        for i in range(n_threads):
+            carrier = wtt.inject_context_carrier()
+            print(carrier)
+            futures.append(pool.submit(thread_work, i, carrier))
+
+    for worker in as_completed(futures):
+        ret = worker.result()
+        print(f"Returned Worker #{ret}")
+
+
+########################################################################################
+
+
+if __name__ == "__main__":
+    coloredlogs.install(level="DEBUG")
+
+    logging.warning("EXAMPLE #1 - No carrier")
+    example_1_no_carrier(3)
+
+    logging.warning("EXAMPLE #1 - With carrier")
+    example_2_w_carrier(3)

--- a/examples/wipac_tracing/span_multithreaded.py
+++ b/examples/wipac_tracing/span_multithreaded.py
@@ -56,7 +56,7 @@ def example_2_w_carrier(n_threads: int) -> None:
     futures: List[Future] = []  # type: ignore[type-arg]
     with ThreadPoolExecutor() as pool:
         for i in range(n_threads):
-            carrier = wtt.inject_context_carrier()
+            carrier = wtt.inject_span_carrier()
             print(carrier)
             futures.append(pool.submit(thread_work, i, carrier))
 

--- a/examples/wipac_tracing/span_multithreaded_multiproccessed.py
+++ b/examples/wipac_tracing/span_multithreaded_multiproccessed.py
@@ -76,7 +76,7 @@ def example_10_threads(n_threads: int) -> None:
 
 @wtt.spanned(all_args=True, carrier="carrier")
 def process_work(worker: int, carrier: Dict[str, Any]) -> int:
-    """Do thread's work."""
+    """Do child process's work."""
     print(carrier)
     time.sleep(1)
     return worker
@@ -84,7 +84,7 @@ def process_work(worker: int, carrier: Dict[str, Any]) -> int:
 
 @wtt.spanned()
 def example_20_processes(n_threads: int) -> None:
-    """Run multiple independent threads, with a common carrier."""
+    """Run multiple independent process, with a common carrier."""
     futures: List[Future] = []  # type: ignore[type-arg]
     with ProcessPoolExecutor() as pool:
         for i in range(n_threads):

--- a/examples/wipac_tracing/span_multithreaded_multiproccessed.py
+++ b/examples/wipac_tracing/span_multithreaded_multiproccessed.py
@@ -1,5 +1,7 @@
 """Examples for spanned() decorator with multi-threaded/processed tracing."""
 
+# pylint: disable=protected-access
+
 
 import logging
 import os
@@ -25,12 +27,25 @@ import wipac_telemetry.tracing_tools as wtt  # noqa: E402 # pylint: disable=C041
 
 
 @wtt.spanned()
-def example_00_threads_no_carrier(n_threads: int) -> None:
-    """Run multiple independent threads, without a common carrier."""
+def example_00_threads_incorrect(n_threads: int) -> None:
+    """Run multiple independent threads, INCORRECTLY.
+
+    Spanning an in-thread function will not inherit ANYTHING. The
+    resulting span is completely not related in any way to the
+    *intended* parent.
+
+    Don't do this!
+    """
+    outter_span = wtt.get_current_span()
 
     @wtt.spanned(all_args=True)
     def thread_work(worker: int) -> int:
         """Do thread's work."""
+        assert outter_span.is_recording()  # surprising? this is b/c of shared memory
+        assert wtt.get_current_span().is_recording()  # as expected
+        assert outter_span != wtt.get_current_span()  # good
+        assert not wtt.get_current_span()._parent  # NOT GOOD!
+        # # # #
         time.sleep(1)
         return worker
 
@@ -44,16 +59,100 @@ def example_00_threads_no_carrier(n_threads: int) -> None:
         print(f"Returned Worker #{ret}")
 
 
+@wtt.spanned()
+def example_01_threads_incorrect(n_threads: int) -> None:
+    """Run multiple independent threads, INCORRECTLY.
+
+    A non-spanned in-thread function won't be spanned by its *intended*
+    parent.
+
+    Don't do this!
+    """
+    outter_span = wtt.get_current_span()
+
+    def thread_work(worker: int, carrier: Dict[str, Any]) -> int:
+        """Do thread's work."""
+        assert outter_span.is_recording()  # surprising? this is b/c of shared memory
+        assert not wtt.get_current_span().is_recording()  # BAD!
+        assert outter_span != wtt.get_current_span()  # good
+        # assert wtt.get_current_span()._parent # (n/a b/c not recording)
+        # # # #
+        print(carrier)
+        time.sleep(1)
+        # shared memory allows this -- but not a great idea logically...
+        outter_span.add_event("I'm", {"A": "Thread"})
+        return worker
+
+    futures: List[Future] = []  # type: ignore[type-arg]
+    with ThreadPoolExecutor() as pool:
+        for i in range(n_threads):
+            carrier = wtt.inject_span_carrier()
+            print(carrier)
+            futures.append(pool.submit(thread_work, i, carrier))
+
+    for worker in as_completed(futures):
+        ret = worker.result()
+        wtt.add_event("Worker Join", {"worker-id": ret, "type": "thread"})
+        print(f"Returned Worker #{ret}")
+
+
+@wtt.spanned()
+def example_02_threads_incorrect(n_threads: int) -> None:
+    """Run multiple independent threads, INCORRECTLY.
+
+    A re-spanned in-thread function may work, but is NOT SAFE. There's a
+    race condition: a parent process/thread may end the span before the
+    child thread uses it, or visa-versa. It's not a good idea.
+
+    Don't do this!
+    """
+    outter_span = wtt.get_current_span()
+
+    # even with `wtt.SpanBehavior.DONT_END`, this isn't a good idea
+    @wtt.respanned("span", wtt.SpanBehavior.END_ON_EXIT)
+    def thread_work(worker: int, span: wtt.Span) -> int:
+        """Do thread's work."""
+        assert span == outter_span == wtt.get_current_span()
+        assert outter_span.is_recording()  # sure
+        assert wtt.get_current_span().is_recording()  # as expected
+        assert outter_span == wtt.get_current_span()  # as expected
+        assert not wtt.get_current_span()._parent
+        # # # #
+        # print(carrier)
+        time.sleep(1)
+        # shared memory allows this -- but not a great idea logically...
+        outter_span.add_event("I'm", {"A": "Thread"})
+        return worker
+
+    futures: List[Future] = []  # type: ignore[type-arg]
+    with ThreadPoolExecutor() as pool:
+        for i in range(n_threads):
+            # carrier = wtt.inject_span_carrier()
+            # print(carrier)
+            futures.append(pool.submit(thread_work, i, outter_span))
+
+    for worker in as_completed(futures):
+        ret = worker.result()
+        wtt.add_event("Worker Join", {"worker-id": ret, "type": "thread"})
+        print(f"Returned Worker #{ret}")
+
+
 ########################################################################################
 
 
 @wtt.spanned()
 def example_10_threads(n_threads: int) -> None:
     """Run multiple independent threads, with a common carrier."""
+    outter_span = wtt.get_current_span()
 
     @wtt.spanned(all_args=True, carrier="carrier")
     def thread_work(worker: int, carrier: Dict[str, Any]) -> int:
         """Do thread's work."""
+        assert outter_span.is_recording()  # surprising? this is b/c of shared memory
+        assert wtt.get_current_span().is_recording()  # as expected
+        assert outter_span != wtt.get_current_span()  # good
+        assert wtt.get_current_span()._parent  # GREAT!
+        # # # #
         print(carrier)
         time.sleep(1)
         return worker
@@ -104,11 +203,26 @@ def example_20_processes(n_threads: int) -> None:
 if __name__ == "__main__":
     coloredlogs.install(level="DEBUG")
 
-    logging.warning("EXAMPLE #0 - Threaded, No Carrier")
-    example_00_threads_no_carrier(3)
+    # MULTI-THREADING
+
+    logging.warning("EXAMPLE #00 - Threaded Incorrectly")
+    example_00_threads_incorrect(3)
+
+    logging.warning("EXAMPLE #01 - Threaded Incorrectly")
+    example_01_threads_incorrect(3)
+
+    logging.warning("EXAMPLE #02 - Threaded Incorrectly")
+    example_02_threads_incorrect(3)
 
     logging.warning("EXAMPLE #10 - Threaded with Carrier")
     example_10_threads(3)
 
+    # MULTI-PROCESSING
+
     logging.warning("EXAMPLE #20 - Processes with Carrier")
     example_20_processes(3)
+
+    # At this point you may be wondering,
+    # "Well what happens if I use 'respanned' with multi-processing?"
+    # Bad things, bad things will happen: inconsistent sem-lock
+    # errors/timeouts, hanging processes, etc.

--- a/examples/wipac_tracing/span_multithreaded_multiproccessed.py
+++ b/examples/wipac_tracing/span_multithreaded_multiproccessed.py
@@ -104,10 +104,10 @@ def example_20_processes(n_threads: int) -> None:
 if __name__ == "__main__":
     coloredlogs.install(level="DEBUG")
 
-    logging.warning("EXAMPLE #0 - Treaded, No Carrier")
+    logging.warning("EXAMPLE #0 - Threaded, No Carrier")
     example_00_threads_no_carrier(3)
 
-    logging.warning("EXAMPLE #10 - Treaded with Carrier")
+    logging.warning("EXAMPLE #10 - Threaded with Carrier")
     example_10_threads(3)
 
     logging.warning("EXAMPLE #20 - Processes with Carrier")

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -12,14 +12,14 @@ from opentelemetry.sdk.trace.export import (  # type: ignore[import]
     SimpleSpanProcessor,
 )
 
-from . import propagations  # noqa
 from .config import CONFIG
 from .events import evented  # noqa
+from .propagations import inject_context_carrier  # noqa
 from .spans import SpanBehavior, make_link, respanned, spanned  # noqa
 from .utils import Link, Span, SpanKind, get_current_span  # noqa
 
 __all__ = [
-    "propagations",
+    "inject_context_carrier",
     "evented",
     "make_link",
     "spanned",

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -14,12 +14,12 @@ from opentelemetry.sdk.trace.export import (  # type: ignore[import]
 
 from .config import CONFIG
 from .events import evented  # noqa
-from .propagations import inject_context_carrier  # noqa
+from .propagations import inject_span_carrier  # noqa
 from .spans import SpanBehavior, make_link, respanned, spanned  # noqa
 from .utils import Link, Span, SpanKind, get_current_span  # noqa
 
 __all__ = [
-    "inject_context_carrier",
+    "inject_span_carrier",
     "evented",
     "make_link",
     "spanned",

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -13,22 +13,23 @@ from opentelemetry.sdk.trace.export import (  # type: ignore[import]
 )
 
 from .config import CONFIG
-from .events import evented  # noqa
+from .events import add_event, evented  # noqa
 from .propagations import inject_span_carrier  # noqa
 from .spans import SpanBehavior, make_link, respanned, spanned  # noqa
 from .utils import Link, Span, SpanKind, get_current_span  # noqa
 
 __all__ = [
-    "inject_span_carrier",
+    "add_event",
     "evented",
-    "make_link",
-    "spanned",
-    "respanned",
-    "Link",
-    "Span",
-    "SpanKind",
     "get_current_span",
+    "inject_span_carrier",
+    "Link",
+    "make_link",
+    "respanned",
+    "Span",
     "SpanBehavior",
+    "SpanKind",
+    "spanned",
 ]
 
 # Config SDK ###########################################################################

--- a/wipac_telemetry/tracing_tools/propagations.py
+++ b/wipac_telemetry/tracing_tools/propagations.py
@@ -3,19 +3,21 @@
 
 from typing import Any, Dict, Optional
 
-from opentelemetry import propagate
+from opentelemetry import propagate  # type: ignore[import]
 
 
 def inject_span_carrier(carrier: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Add current span info to a dict ("carrier") for inter-context tracing.
+    """Add current span info to a dict ("carrier") for distributed tracing.
 
-    A new key, `"traceparent"`, is added which can be used by the child.
-    This is a necessary step to make a span parent-child connection
-    between threads, processes, services, etc.
+    Adds a key, `"traceparent"`, which can be used by the child span to
+    make a parent connection (`parent_id`). This is a necessary step for
+    distributed tracing between threads, processes, services, etc.
 
     Optionally, pass in a ready-to-ship dict. This is for situations
-    where the carrier needs to be serializable, like the HTTP headers
-    dict.
+    where the carrier needs to be a payload within an established
+    protocol, like the HTTP-headers dict.
+
+    Returns the carrier (dict) with the added info.
     """
     if not carrier:
         carrier = {}

--- a/wipac_telemetry/tracing_tools/propagations.py
+++ b/wipac_telemetry/tracing_tools/propagations.py
@@ -1,6 +1,24 @@
 """Tools for cross-service propagation."""
 
 
+from typing import Any, Dict, Optional
+
 from opentelemetry import propagate  # type: ignore[import]
 
-inject = propagate.inject  # Inject the Span Context for HTTP tracing propagation
+
+def inject_context_carrier(carrier: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Inject current tracing info into a dict for inter-context spanning.
+
+    This is a necessary step to make a span parent-child contention
+    between threads, processes, machines, etc.
+
+    Optionally, pass in a ready-to-ship dict. This is for situations
+    where the carrier needs to be serializable, like the HTTP headers
+    dict.
+    """
+    if not carrier:
+        carrier = {}
+
+    propagate.inject(carrier)
+
+    return carrier

--- a/wipac_telemetry/tracing_tools/propagations.py
+++ b/wipac_telemetry/tracing_tools/propagations.py
@@ -6,11 +6,11 @@ from typing import Any, Dict, Optional
 from opentelemetry import propagate  # type: ignore[import]
 
 
-def inject_context_carrier(carrier: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def inject_span_carrier(carrier: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Inject current tracing info into a dict for inter-context spanning.
 
-    This is a necessary step to make a span parent-child contention
-    between threads, processes, machines, etc.
+    This is a necessary step to make a span parent-child connection
+    between threads, processes, services, etc.
 
     Optionally, pass in a ready-to-ship dict. This is for situations
     where the carrier needs to be serializable, like the HTTP headers

--- a/wipac_telemetry/tracing_tools/propagations.py
+++ b/wipac_telemetry/tracing_tools/propagations.py
@@ -3,12 +3,13 @@
 
 from typing import Any, Dict, Optional
 
-from opentelemetry import propagate  # type: ignore[import]
+from opentelemetry import propagate
 
 
 def inject_span_carrier(carrier: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Inject current tracing info into a dict for inter-context spanning.
+    """Add current span info to a dict ("carrier") for inter-context tracing.
 
+    A new key, `"traceparent"`, is added which can be used by the child.
     This is a necessary step to make a span parent-child connection
     between threads, processes, services, etc.
 

--- a/wipac_telemetry/tracing_tools/spans.py
+++ b/wipac_telemetry/tracing_tools/spans.py
@@ -103,9 +103,7 @@ class _NewSpanConductor(_SpanConductor):
 
         tracer_name = inspect.getfile(inspector.func)  # Ex: /path/to/file.py
 
-        if self.kind == SpanKind.SERVER:
-            context = extract(inspector.resolve_attr("self.request.headers"))
-        elif self.carrier:
+        if self.carrier:
             context = extract(inspector.resolve_attr(self.carrier))
         else:
             context = None  # `None` will default to current context
@@ -308,11 +306,9 @@ def spanned(
                         + use this when re-use is needed and an exception is NOT expected
         links -- a list of variable names of `Link` instances (span-links) - useful for cross-process tracing
         kind -- a `SpanKind` enum value
-                - ``SpanKind.INTERNAL` - (default) normal, in-application spans
+                - `SpanKind.INTERNAL` - (default) normal, in-application spans
                 - `SpanKind.CLIENT` - spanned function makes outgoing cross-service requests
                 - `SpanKind.SERVER` - spanned function handles incoming cross-service requests
-                    * contextually connected to a client-service's span via parent pointer
-                    * (looks at `self.request` instance for necessary info)
                 - `SpanKind.CONSUMER` - spanned function makes outgoing cross-service messages
                 - `SpanKind.PRODUCER` - spanned function handles incoming cross-service messages
         carrier -- the name of the variable containing the context-carrier - useful for cross-process/service tracing

--- a/wipac_telemetry/tracing_tools/spans.py
+++ b/wipac_telemetry/tracing_tools/spans.py
@@ -392,7 +392,7 @@ def respanned(
 
 ########################################################################################
 
-# TODO - figure out what to do with linking
+# TODO - figure out what to do with linking -> probably peer-to-peer / message-passing
 
 
 def make_link(

--- a/wipac_telemetry/tracing_tools/spans.py
+++ b/wipac_telemetry/tracing_tools/spans.py
@@ -160,12 +160,13 @@ class _ReuseSpanConductor(_SpanConductor):
 
         span.add_event(inspector.func.__qualname__, self.auto_event_attrs(attrs))
 
-        if self.behavior == SpanBehavior.END_ON_EXIT and span == get_current_span():
-            raise InvalidSpanBehavior(
-                "Attempting to re-span an already recording span "
-                "with `behavior=SpanBehavior.END_ON_EXIT` "
-                "(callee should not explicitly end caller's span)."
-            )
+        if self.behavior == SpanBehavior.END_ON_EXIT:
+            if span == get_current_span():
+                raise InvalidSpanBehavior(
+                    'Attempting to re-span the "current" span '
+                    "with `behavior=SpanBehavior.END_ON_EXIT` "
+                    "(callee should not explicitly end caller's span)."
+                )
 
         LOGGER.info(
             f"Re-using span `{span.name}` "


### PR DESCRIPTION
- First round of tracing support for multi-threading and multi-processing
- This is one-half of fully supporting distributed processing (the other being peer-to-peer message passing)

How to make the parent-child span relation:
- Parent Side:
	- Requires an inter-thread/process/service payload `dict` (aka the carrier)
	- And a one in-line call `inject_span_carrier()` which will add the necessary info to the carrier
- Child Side:
	- Requires the `carrier` argument in the `@spanned()` decorator with the name of the inter-thread/process/service payload `dict` (aka the carrier) variable

I included an HTTP client-server example, other examples for different protocols can be included if there's interest. 

These changes will require a small tweak in https://github.com/WIPACrepo/rest-tools/issues/24.

closes https://github.com/WIPACrepo/wipac-telemetry-prototype/issues/13