### PR TITLE
Allow Other Types as Span Attributes

### DIFF
--- a/wipac_telemetry/tracing_tools/spans.py
+++ b/wipac_telemetry/tracing_tools/spans.py
@@ -118,7 +118,7 @@ class _NewSpanConductor(_SpanConductor):
 
         tracer = get_tracer(tracer_name)
         span = tracer.start_span(
-            span_name, context=context, kind=self.kind, attributes=attrs, links=links,
+            span_name, context=context, kind=self.kind, attributes=attrs, links=links
         )
         span.add_event(span_name, self.auto_event_attrs(attrs))
 
@@ -335,7 +335,7 @@ def spanned(
             kind,
             carrier,
             carrier_relation,
-        ),
+        )
     )
 
 
@@ -384,5 +384,5 @@ def respanned(
             {"attributes": attributes, "all_args": all_args, "these": these},
             behavior,
             span_var_name,
-        ),
+        )
     )

--- a/wipac_telemetry/tracing_tools/utils.py
+++ b/wipac_telemetry/tracing_tools/utils.py
@@ -138,18 +138,23 @@ def convert_to_attributes(
 
     out = {}
     legal_types = (str, bool, int, float)
+
     for attr in list(raw):
+        # check if simple, single type
         if isinstance(raw[attr], legal_types):
             out[attr] = copy.deepcopy(raw[attr])
-            continue
-        # check all members of sequence are of same (legal) type
-        if isinstance(raw[attr], Sequence):
+
+        # is this a sequence?
+        elif isinstance(raw[attr], Sequence):
             member_types = list(set(type(m) for m in raw[attr]))
+            # if every member is same (legal) type, copy it all
             if len(member_types) == 1 and member_types[0] in legal_types:
                 out[attr] = copy.deepcopy(raw[attr])
-                continue
-            out[attr] = [repr(v) for v in raw[attr]]
+            else:
+                out[attr] = [repr(v) for v in raw[attr]]  # retain list, but as reprs
+
         # other types -> get `repr()`
-        out[attr] = repr(raw[attr])
+        else:
+            out[attr] = repr(raw[attr])
 
     return out


### PR DESCRIPTION
Now, 

> Values that aren't str/bool/int/float (or homogeneous sequences of these) are swapped for their `repr()` strings, wholesale.

closes https://github.com/WIPACrepo/wipac-telemetry-prototype/issues/25