### PR TITLE
Modify WIPAC Telemetry for HTTP/JSON protocol

### DIFF
--- a/examples/wipac_tracing/run_all_examples.sh
+++ b/examples/wipac_tracing/run_all_examples.sh
@@ -1,6 +1,7 @@
 # Run all the example python files
 
-export OTEL_EXPORTER_OTLP_ENDPOINT="localhost:4317"
+export OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:="http://localhost:4318/v1/traces"}
+export WIPACTEL_EXPORT_STDOUT=${WIPACTEL_EXPORT_STDOUT:="FALSE"}
 
 files=`find examples/wipac_tracing/ -name '*.py' -a ! -name 'span_client_server_http.py' -a ! -name 'span_peer_to_peer_example.py'`
 for f in $files; do python "$f"; done

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 git+https://github.com/WIPACrepo/wipac-dev-tools@v1.0.11#egg=wipac_dev_tools
 coloredlogs==15.0.1
-opentelemetry-api==1.2.0
-opentelemetry-exporter-jaeger==1.2.0
-opentelemetry-exporter-otlp==1.2.0
+opentelemetry-api==1.5.0
+opentelemetry-exporter-jaeger==1.5.0
+opentelemetry-exporter-otlp==1.5.0
+opentelemetry-exporter-otlp-proto-grpc==1.5.0
+opentelemetry-exporter-otlp-proto-http==1.5.0
 opentelemetry-instrumentation-flask
 opentelemetry-instrumentation-requests
-opentelemetry-propagator-b3==1.2.0
-opentelemetry-sdk==1.2.0
+opentelemetry-propagator-b3==1.5.0
+opentelemetry-sdk==1.5.0
 pika==1.2.0

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -1,7 +1,8 @@
 """Init."""
 
 
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # type: ignore[import]
+# from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # type: ignore[import]
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # type: ignore[import]
     OTLPSpanExporter,
 )
 from opentelemetry.sdk.trace import TracerProvider  # type: ignore[import]


### PR DESCRIPTION
* Modify local Docker script to pull recent images and listen on HTTP/JSON port
* Modify run-all-examples to use the HTTP/JSON protocol
* Bump OpenTelemetry dependency from 1.2.0 to 1.5.0
* Modify WIPAC's tracing_tools to use the HTTP/JSON OTLPSpanExporter
