### PR TITLE
Type-Hint Backward Compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ opentelemetry-instrumentation-requests
 opentelemetry-propagator-b3==1.5.0
 opentelemetry-sdk==1.5.0
 pika==1.2.0
+typing-extensions

--- a/wipac_telemetry/tracing_tools/config.py
+++ b/wipac_telemetry/tracing_tools/config.py
@@ -1,7 +1,12 @@
 """Tracing config file."""
 
 import logging
-from typing import TypedDict, cast
+from typing import cast
+
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict
 
 from wipac_dev_tools import from_environment
 from wipac_dev_tools.enviro_tools import KeySpec

--- a/wipac_telemetry/tracing_tools/spans.py
+++ b/wipac_telemetry/tracing_tools/spans.py
@@ -5,12 +5,12 @@ import asyncio
 import inspect
 from enum import Enum, auto
 from functools import wraps
-from typing import Any, Callable, Final, List, Optional
+from typing import Any, Callable, List, Optional
 
 try:
-    from typing import TypedDict
+    from typing import Final, TypedDict
 except ImportError:
-    from typing_extensions import TypedDict
+    from typing_extensions import TypedDict, Final
 
 from opentelemetry.propagate import extract
 from opentelemetry.trace import Span, SpanKind, get_current_span, get_tracer, use_span

--- a/wipac_telemetry/tracing_tools/spans.py
+++ b/wipac_telemetry/tracing_tools/spans.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, List, Optional
 try:
     from typing import Final, TypedDict
 except ImportError:
-    from typing_extensions import TypedDict, Final
+    from typing_extensions import Final, TypedDict  # type: ignore[misc]
 
 from opentelemetry.propagate import extract
 from opentelemetry.trace import Span, SpanKind, get_current_span, get_tracer, use_span

--- a/wipac_telemetry/tracing_tools/spans.py
+++ b/wipac_telemetry/tracing_tools/spans.py
@@ -5,7 +5,12 @@ import asyncio
 import inspect
 from enum import Enum, auto
 from functools import wraps
-from typing import Any, Callable, Final, List, Optional, TypedDict
+from typing import Any, Callable, Final, List, Optional
+
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict
 
 from opentelemetry.propagate import extract
 from opentelemetry.trace import Span, SpanKind, get_current_span, get_tracer, use_span


### PR DESCRIPTION
The library should now work with 3.6+.

`TypedDict` and `Final` are both common "new" types (3.8+).