### PR TITLE
Don't Record `StopIteration`s as Errors When They Aren't

### DIFF
--- a/examples/wipac_tracing/run_all_examples.sh
+++ b/examples/wipac_tracing/run_all_examples.sh
@@ -1,15 +1,28 @@
 # Run all the example python files
 
 export OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:="http://localhost:4318/v1/traces"}
-# export WIPACTEL_EXPORT_STDOUT=${WIPACTEL_EXPORT_STDOUT:="FALSE"}
+# export WIPACTEL_EXPORT_STDOUT=${WIPACTEL_EXPORT_STDOUT:="TRUE"}
 
-files=`find examples/wipac_tracing/ -name '*.py' -a ! -name 'span_client_server_http.py' -a ! -name 'span_peer_to_peer_example.py'`
-for f in $files; do python "$f"; done
+divider=`printf '=%.0s' {1..100}`
 
+for fpath in `find examples/wipac_tracing/ -name '*.py'`; do
+	fname=`basename $fpath`
+	if [ $fname == "span_client_server_http.py" ] || [ $fname == "span_peer_to_peer_example.py" ]; then
+		continue
+	fi
+	echo $divider
+	echo "$fpath"
+	python "$fpath"
+done
+
+echo $divider
+echo "examples/wipac_tracing/span_client_server_http.py"
 python examples/wipac_tracing/span_client_server_http.py server &
 python examples/wipac_tracing/span_client_server_http.py client &
 wait
 
+echo $divider
+echo "examples/wipac_tracing/span_peer_to_peer_example.py"
 python examples/wipac_tracing/span_peer_to_peer_example.py hank george &
 python examples/wipac_tracing/span_peer_to_peer_example.py george hank &
 wait

--- a/examples/wipac_tracing/spanned_example.py
+++ b/examples/wipac_tracing/spanned_example.py
@@ -186,8 +186,8 @@ async def example_20_async() -> None:
 
 
 @wtt.spanned()
-def example_30_iter_a_generator() -> None:
-    """Span a generator."""
+def example_30_iter_a_generator_function() -> None:
+    """Span a generator (from a basic iterator function)."""
 
     @wtt.spanned()
     def _gen() -> Generator[int, None, None]:
@@ -200,6 +200,41 @@ def example_30_iter_a_generator() -> None:
         time.sleep(0.25)
 
     for num in _gen():
+        print(num)
+        time.sleep(0.25)
+
+
+@wtt.spanned()
+def example_31_iter_a_generator_class() -> None:
+    """Span a generator (from a generator class instance)."""
+
+    class Fib:
+        """Fibonacci generator-iterator."""
+
+        def __init__(self, max: int) -> None:
+            self.a, self.b = 0, 1
+            self.max = 5
+            self.i = 0
+
+        @wtt.spanned()
+        def __next__(self) -> int:
+            if self.max == self.i:
+                raise StopIteration
+            return_value = self.a
+            self.a, self.b = self.b, self.a + self.b
+            self.i += 1
+            return return_value
+
+        @wtt.spanned()
+        def __iter__(self) -> "Fib":
+            return self
+
+    gen = Fib(5)
+    for num in gen:
+        print(num)
+        time.sleep(0.25)
+
+    for num in Fib(5):
         print(num)
         time.sleep(0.25)
 
@@ -294,5 +329,8 @@ if __name__ == "__main__":
     logging.warning("EXAMPLE #20 - NESTED ASYNC")
     asyncio.get_event_loop().run_until_complete(example_20_async())
 
-    logging.warning("EXAMPLE #30 - GENERATOR")
-    example_30_iter_a_generator()
+    logging.warning("EXAMPLE #30 - GENERATOR FUNCTION")
+    example_30_iter_a_generator_function()
+
+    logging.warning("EXAMPLE #31 - GENERATOR CLASS")
+    example_31_iter_a_generator_class()

--- a/wipac_telemetry/tracing_tools/spans.py
+++ b/wipac_telemetry/tracing_tools/spans.py
@@ -241,6 +241,7 @@ def _spanned(conductor: _SpanConductor) -> Callable[..., Any]:
                     raise StopIteration
                 raise RuntimeError("Malformed SpanBehavior Handling")
             # CASE 3 ----------------------------------------------------------
+            # NOTE: logic is identical to above case, except end behavior
             elif conductor.behavior == SpanBehavior.DONT_END:
                 with use_span(span, end_on_exit=False):
                     try:
@@ -262,6 +263,7 @@ def _spanned(conductor: _SpanConductor) -> Callable[..., Any]:
             LOGGER.debug("Spanned Generator Function")
             span = setup(args, kwargs)
 
+            # CASE 1 ----------------------------------------------------------
             if conductor.behavior == SpanBehavior.ONLY_END_ON_EXCEPTION:
                 try:
                     with use_span(span, end_on_exit=False):
@@ -270,14 +272,18 @@ def _spanned(conductor: _SpanConductor) -> Callable[..., Any]:
                 except:  # noqa: E722 # pylint: disable=bare-except
                     span.end()
                     raise
+            # CASE 2 ----------------------------------------------------------
             elif conductor.behavior == SpanBehavior.END_ON_EXIT:
                 with use_span(span, end_on_exit=True):
                     for val in func(*args, **kwargs):
                         yield val
+            # CASE 3 ----------------------------------------------------------
+            # NOTE: logic is identical to above case, except end behavior
             elif conductor.behavior == SpanBehavior.DONT_END:
                 with use_span(span, end_on_exit=False):
                     for val in func(*args, **kwargs):
                         yield val
+            # ELSE ------------------------------------------------------------
             else:
                 raise InvalidSpanBehavior(conductor.behavior)
 
@@ -286,6 +292,7 @@ def _spanned(conductor: _SpanConductor) -> Callable[..., Any]:
             LOGGER.debug("Spanned Async Function")
             span = setup(args, kwargs)
 
+            # CASE 1 ----------------------------------------------------------
             if conductor.behavior == SpanBehavior.ONLY_END_ON_EXCEPTION:
                 try:
                     with use_span(span, end_on_exit=False):
@@ -293,12 +300,16 @@ def _spanned(conductor: _SpanConductor) -> Callable[..., Any]:
                 except:  # noqa: E722 # pylint: disable=bare-except
                     span.end()
                     raise
+            # CASE 2 ----------------------------------------------------------
             elif conductor.behavior == SpanBehavior.END_ON_EXIT:
                 with use_span(span, end_on_exit=True):
                     return await func(*args, **kwargs)
+            # CASE 3 ----------------------------------------------------------
+            # NOTE: logic is identical to above case, except end behavior
             elif conductor.behavior == SpanBehavior.DONT_END:
                 with use_span(span, end_on_exit=False):
                     return await func(*args, **kwargs)
+            # ELSE ------------------------------------------------------------
             else:
                 raise InvalidSpanBehavior(conductor.behavior)
 


### PR DESCRIPTION
Got a little creative in the wrapper code, but it's all there. The interesting part was detecting whether the `StopIteration` came from a `__next__()` method (of an iterator object instance) or from another case (like manually calling `next()` too many times). 

If the `@spanned()` wrapper (wrapping `__next__()`) is given a custom span name, this logic breaks, a `StopIteration` is recorded, and the span is marked as an error.

This PR does not address async iterators.

fixes https://github.com/WIPACrepo/wipac-telemetry-prototype/issues/24