### PR TITLE
Service Name Patches

### DIFF
--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -1,6 +1,7 @@
 """Init."""
 
 
+import datetime
 import hashlib
 import os
 import sys
@@ -64,9 +65,14 @@ def get_service_name() -> str:
         # this means client is running as a module, so get the full package name + version
         name = main_mod_abspath.rstrip("__main__.py").split("/")[-1]
         here = main_mod_abspath.rstrip(f"/{name}/__main__.py")
-        version = SetupShop._get_version(here, name)  # pylint:disable=protected-access
-        version = ".".join([x.zfill(2) for x in version.split(".")])  # ex: 01.02.03
-        service_name = f"{sys.modules['__main__'].__package__} (v{version})"
+        try:
+            # pylint:disable=protected-access
+            version = SetupShop._get_version(here, name)
+            version = ".".join([x.zfill(2) for x in version.split(".")])  # ex: 01.02.03
+            version = "v" + version
+        except:  # noqa: E722 # pylint:disable=bare-except
+            version = datetime.date.today().isoformat()
+        service_name = f"{sys.modules['__main__'].__package__} ({version})"
     else:
         # otherwise, client is running as a script, so use the file's name
         script = main_mod_abspath.split("/")[-1]  # ex: 'myscript.py'

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -27,7 +27,7 @@ from opentelemetry.trace import (  # noqa
 )
 from wipac_dev_tools import SetupShop
 
-from .config import CONFIG
+from .config import CONFIG, LOGGER
 from .events import add_event, evented  # noqa
 from .propagations import (  # noqa
     extract_links_carrier,
@@ -54,7 +54,6 @@ __all__ = [
     "spanned",
 ]
 
-_LOGGER = logging.getLogger("wipactel")
 
 # Config SDK ###########################################################################
 
@@ -62,7 +61,7 @@ _LOGGER = logging.getLogger("wipactel")
 def get_service_name() -> str:
     """Build the service name from module/script auto-detection."""
     main_mod_abspath = os.path.abspath(sys.modules["__main__"].__file__)
-    _LOGGER.debug(f"Detecting Service Name from `{main_mod_abspath}`...")
+    LOGGER.debug(f"Detecting Service Name from `{main_mod_abspath}`...")
 
     if main_mod_abspath.endswith("/__main__.py"):
         # this means client is running as a module, so get the full package name + version
@@ -83,27 +82,25 @@ def get_service_name() -> str:
             readable_hash = hashlib.sha256(f.read()).hexdigest()
         service_name = f"./{script} ({readable_hash[-4:]})"
 
-    _LOGGER.debug(f"Using Service Name: {service_name}...")
+    LOGGER.debug(f"Using Service Name: {service_name}...")
     return service_name
 
 
-_LOGGER.info("Setting Tracer Provider...")
+LOGGER.info("Setting Tracer Provider...")
 set_tracer_provider(
     TracerProvider(resource=Resource.create({SERVICE_NAME: get_service_name()}))
 )
 
 
 if CONFIG["WIPACTEL_EXPORT_STDOUT"]:
-    _LOGGER.info("Adding ConsoleSpanExporter...")
+    LOGGER.info("Adding ConsoleSpanExporter...")
     get_tracer_provider().add_span_processor(
         # output to stdout
         SimpleSpanProcessor(ConsoleSpanExporter())
     )
 
 if CONFIG["OTEL_EXPORTER_OTLP_ENDPOINT"]:
-    _LOGGER.info(
-        f"Adding OTLPSpanExporter ({CONFIG['OTEL_EXPORTER_OTLP_ENDPOINT']})..."
-    )
+    LOGGER.info(f"Adding OTLPSpanExporter ({CONFIG['OTEL_EXPORTER_OTLP_ENDPOINT']})...")
     get_tracer_provider().add_span_processor(
         # relies on env variables
         # -- https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -63,7 +63,14 @@ def _pseudo_log(msg: str) -> None:
 
 def get_service_name() -> str:
     """Build the service name from module/script auto-detection."""
-    main_mod_abspath = os.path.abspath(sys.modules["__main__"].__file__)
+    try:
+        main_mod_abspath = os.path.abspath(sys.modules["__main__"].__file__)
+    except AttributeError as e:
+        raise RuntimeError(
+            "Telemetry service started up before '__main__' was set. "
+            "Do you have imports in your package's base '__init__.py'? "
+            "If so, remove those."
+        ) from e
     _pseudo_log(f"Detecting Service Name from `{main_mod_abspath}`...")
 
     if main_mod_abspath.endswith("/__main__.py"):

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -1,8 +1,8 @@
 """Init."""
 
-
 import datetime
 import hashlib
+import logging
 import os
 import sys
 
@@ -54,6 +54,7 @@ __all__ = [
     "spanned",
 ]
 
+_LOGGER = logging.getLogger("wipactel")
 
 # Config SDK ###########################################################################
 
@@ -61,6 +62,8 @@ __all__ = [
 def get_service_name() -> str:
     """Build the service name from module/script auto-detection."""
     main_mod_abspath = os.path.abspath(sys.modules["__main__"].__file__)
+    _LOGGER.debug(f"Detecting Service Name from `{main_mod_abspath}`...")
+
     if main_mod_abspath.endswith("/__main__.py"):
         # this means client is running as a module, so get the full package name + version
         name = main_mod_abspath.rstrip("__main__.py").split("/")[-1]
@@ -80,22 +83,28 @@ def get_service_name() -> str:
             readable_hash = hashlib.sha256(f.read()).hexdigest()
         service_name = f"./{script} ({readable_hash[-4:]})"
 
+    _LOGGER.debug(f"Using Service Name: {service_name}...")
     return service_name
 
 
+_LOGGER.info("Setting Tracer Provider...")
 set_tracer_provider(
     TracerProvider(resource=Resource.create({SERVICE_NAME: get_service_name()}))
 )
 
 
 if CONFIG["WIPACTEL_EXPORT_STDOUT"]:
-    get_tracer_provider().add_span_processor(  # type: ignore[attr-defined]
+    _LOGGER.info("Adding ConsoleSpanExporter...")
+    get_tracer_provider().add_span_processor(
         # output to stdout
         SimpleSpanProcessor(ConsoleSpanExporter())
     )
 
 if CONFIG["OTEL_EXPORTER_OTLP_ENDPOINT"]:
-    get_tracer_provider().add_span_processor(  # type: ignore[attr-defined]
+    _LOGGER.info(
+        f"Adding OTLPSpanExporter ({CONFIG['OTEL_EXPORTER_OTLP_ENDPOINT']})..."
+    )
+    get_tracer_provider().add_span_processor(
         # relies on env variables
         # -- https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html
         # OTEL_EXPORTER_OTLP_TRACES_TIMEOUT

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -2,6 +2,7 @@
 
 import datetime
 import hashlib
+import logging
 import os
 import sys
 
@@ -55,9 +56,6 @@ __all__ = [
 
 
 # Config SDK ###########################################################################
-
-# FIXME - logging isn't logged!
-assert 0
 
 
 def get_service_name() -> str:

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -57,6 +57,9 @@ __all__ = [
 # Config SDK ###########################################################################
 
 print(LOGGER)
+import logging
+
+logging.critical(LOGGER)
 
 
 def get_service_name() -> str:

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -58,7 +58,7 @@ __all__ = [
 
 
 def _pseudo_log(msg: str) -> None:
-    print(f"[wipac-telemetry-setup] : {msg}", file=sys.stderr)
+    print(f"[wipac-telemetry-setup] {msg}", file=sys.stderr)
 
 
 def get_service_name() -> str:
@@ -85,7 +85,7 @@ def get_service_name() -> str:
             readable_hash = hashlib.sha256(f.read()).hexdigest()
         service_name = f"./{script} ({readable_hash[-4:]})"
 
-    _pseudo_log(f"Using Service Name: {service_name}...")
+    _pseudo_log(f'Using Service Name: "{service_name}"')
     return service_name
 
 
@@ -96,14 +96,14 @@ set_tracer_provider(
 
 
 if CONFIG["WIPACTEL_EXPORT_STDOUT"]:
-    _pseudo_log("Adding ConsoleSpanExporter...")
+    _pseudo_log("Adding ConsoleSpanExporter")
     get_tracer_provider().add_span_processor(
         # output to stdout
         SimpleSpanProcessor(ConsoleSpanExporter())
     )
 
 if CONFIG["OTEL_EXPORTER_OTLP_ENDPOINT"]:
-    _pseudo_log(f"Adding OTLPSpanExporter ({CONFIG['OTEL_EXPORTER_OTLP_ENDPOINT']})...")
+    _pseudo_log(f"Adding OTLPSpanExporter ({CONFIG['OTEL_EXPORTER_OTLP_ENDPOINT']})")
     get_tracer_provider().add_span_processor(
         # relies on env variables
         # -- https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html
@@ -121,3 +121,5 @@ if CONFIG["OTEL_EXPORTER_OTLP_ENDPOINT"]:
         # OTEL_EXPORTER_OTLP_CERTIFICATE
         BatchSpanProcessor(OTLPSpanExporter())
     )
+
+_pseudo_log("Setup complete.")

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -2,7 +2,6 @@
 
 import datetime
 import hashlib
-import logging
 import os
 import sys
 
@@ -56,6 +55,8 @@ __all__ = [
 
 
 # Config SDK ###########################################################################
+
+print(LOGGER)
 
 
 def get_service_name() -> str:

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -62,7 +62,9 @@ print(LOGGER)
 def get_service_name() -> str:
     """Build the service name from module/script auto-detection."""
     main_mod_abspath = os.path.abspath(sys.modules["__main__"].__file__)
-    LOGGER.debug(f"Detecting Service Name from `{main_mod_abspath}`...")
+    print(
+        f"DEBUG: Detecting Service Name from `{main_mod_abspath}`...", file=sys.stderr
+    )
 
     if main_mod_abspath.endswith("/__main__.py"):
         # this means client is running as a module, so get the full package name + version
@@ -83,25 +85,28 @@ def get_service_name() -> str:
             readable_hash = hashlib.sha256(f.read()).hexdigest()
         service_name = f"./{script} ({readable_hash[-4:]})"
 
-    LOGGER.debug(f"Using Service Name: {service_name}...")
+    print(f"DEBUG: Using Service Name: {service_name}...", file=sys.stderr)
     return service_name
 
 
-LOGGER.info("Setting Tracer Provider...")
+print("INFO: Setting Tracer Provider...", file=sys.stderr)
 set_tracer_provider(
     TracerProvider(resource=Resource.create({SERVICE_NAME: get_service_name()}))
 )
 
 
 if CONFIG["WIPACTEL_EXPORT_STDOUT"]:
-    LOGGER.info("Adding ConsoleSpanExporter...")
+    print("INFO: Adding ConsoleSpanExporter...", file=sys.stderr)
     get_tracer_provider().add_span_processor(
         # output to stdout
         SimpleSpanProcessor(ConsoleSpanExporter())
     )
 
 if CONFIG["OTEL_EXPORTER_OTLP_ENDPOINT"]:
-    LOGGER.info(f"Adding OTLPSpanExporter ({CONFIG['OTEL_EXPORTER_OTLP_ENDPOINT']})...")
+    print(
+        "INFO: Adding OTLPSpanExporter ({CONFIG['OTEL_EXPORTER_OTLP_ENDPOINT']})...",
+        file=sys.stderr,
+    )
     get_tracer_provider().add_span_processor(
         # relies on env variables
         # -- https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -69,7 +69,8 @@ def get_service_name() -> str:
         raise RuntimeError(
             "WIPAC Telemetry service started up before '__main__' was set. "
             "Do you have imports in your package's base '__init__.py'? "
-            "If so, remove them; one of these is likely prematurely calling this library."
+            "If so, remove them; one of these likely prematurely called "
+            "this library before '__main__.py' was executed."
         ) from e
     _pseudo_log(f"Detecting Service Name from `{main_mod_abspath}`...")
 

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -2,7 +2,6 @@
 
 import datetime
 import hashlib
-import logging
 import os
 import sys
 
@@ -56,6 +55,9 @@ __all__ = [
 
 
 # Config SDK ###########################################################################
+
+# FIXME - logging isn't logged!
+assert 0
 
 
 def get_service_name() -> str:

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -93,6 +93,11 @@ def get_service_name() -> str:
             readable_hash = hashlib.sha256(f.read()).hexdigest()
         service_name = f"./{script} ({readable_hash[-4:]})"
 
+    # check if user supplied a prefix
+    if CONFIG["WIPACTEL_SERVICE_NAME_PREFIX"]:
+        _pseudo_log(f"with prefix: \"{CONFIG['WIPACTEL_SERVICE_NAME_PREFIX']}\"")
+        service_name = f"{CONFIG['WIPACTEL_SERVICE_NAME_PREFIX']}.{service_name}"
+
     _pseudo_log(f'Using Service Name: "{service_name}"')
     return service_name
 

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -67,9 +67,9 @@ def get_service_name() -> str:
         main_mod_abspath = os.path.abspath(sys.modules["__main__"].__file__)
     except AttributeError as e:
         raise RuntimeError(
-            "Telemetry service started up before '__main__' was set. "
+            "WIPAC Telemetry service started up before '__main__' was set. "
             "Do you have imports in your package's base '__init__.py'? "
-            "If so, remove those."
+            "If so, remove them; one of these is likely prematurely calling this library."
         ) from e
     _pseudo_log(f"Detecting Service Name from `{main_mod_abspath}`...")
 

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -96,7 +96,7 @@ def get_service_name() -> str:
     # check if user supplied a prefix
     if CONFIG["WIPACTEL_SERVICE_NAME_PREFIX"]:
         _pseudo_log(f"with prefix: \"{CONFIG['WIPACTEL_SERVICE_NAME_PREFIX']}\"")
-        service_name = f"{CONFIG['WIPACTEL_SERVICE_NAME_PREFIX']}.{service_name}"
+        service_name = f"{CONFIG['WIPACTEL_SERVICE_NAME_PREFIX']}/{service_name}"
 
     _pseudo_log(f'Using Service Name: "{service_name}"')
     return service_name

--- a/wipac_telemetry/tracing_tools/config.py
+++ b/wipac_telemetry/tracing_tools/config.py
@@ -16,12 +16,14 @@ class _TypedConfig(TypedDict):
     OTEL_EXPORTER_OTLP_ENDPOINT: str
     WIPACTEL_EXPORT_STDOUT: bool
     WIPACTEL_LOGGING_LEVEL: str
+    WIPACTEL_SERVICE_NAME_PREFIX: str
 
 
 defaults: _TypedConfig = {
     "OTEL_EXPORTER_OTLP_ENDPOINT": "",
     "WIPACTEL_EXPORT_STDOUT": False,
     "WIPACTEL_LOGGING_LEVEL": "WARNING",
+    "WIPACTEL_SERVICE_NAME_PREFIX": "",
 }
 CONFIG = cast(_TypedConfig, from_environment(cast(KeySpec, defaults)))
 


### PR DESCRIPTION
A few updates were made when testing service name logic with the MOU Dashboard.
- add `WIPACTEL_SERVICE_NAME_PREFIX` environment variable for prefixing service names (ex: `**mou**/web_app`)
- use today's date if `__version__` is not available (`YYYY-MM-DD`); modules/packages only
- add logging (to stderr)
- add error handling for funky importing (see code)
 

![Screenshot from 2021-11-01 17-11-15](https://user-images.githubusercontent.com/19216225/139748801-7b34177e-69fb-4cd3-9776-830f31b506d2.png)
