### PR TITLE
Attempt to use __package__ directly, and bypass __file__ when we don't need it

### DIFF
--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -26,7 +26,6 @@ from opentelemetry.trace import (  # noqa
     get_tracer_provider,
     set_tracer_provider,
 )
-from wipac_dev_tools import SetupShop
 
 from .config import CONFIG
 from .events import add_event, evented  # noqa


### PR DESCRIPTION
 - Attempt to use `__package__` directly, and bypass `__file__` when we don't need it.
 - Upgrade to Path objects for file paths.  
 - Ignore REPL.  
 - Stop printing setup to stderr if not using tracing.