### PR TITLE
Smart Custom Span Name

### DIFF
--- a/examples/wipac_tracing/span_behavior_examples.py
+++ b/examples/wipac_tracing/span_behavior_examples.py
@@ -23,8 +23,14 @@ class DemoClass:
 
     def __init__(self) -> None:
         self.span: Optional[wtt.Span] = None
+        self.name = "DEMO!"
 
-    @wtt.spanned(behavior=wtt.SpanBehavior.ONLY_END_ON_EXCEPTION)
+    @wtt.spanned(
+        span_namer=wtt.SpanNamer(
+            literal_name="TheBestPrepare", use_this_arg="self.name"
+        ),
+        behavior=wtt.SpanBehavior.ONLY_END_ON_EXCEPTION,
+    )
     def prepare(self) -> None:
         """Do some things and start an independent span."""
         self.span = wtt.get_current_span()
@@ -116,8 +122,15 @@ class ExternalClass:
 
     def __init__(self, span: wtt.Span) -> None:
         self.span = span
+        self.name = "TheExternalClass!"
 
-    @wtt.spanned()  # sets current_span
+    @wtt.spanned(
+        span_namer=wtt.SpanNamer(
+            literal_name="DISJOINT_SPANNED_METHOD",
+            use_this_arg="self.name",
+            use_function_name=False,
+        )
+    )  # sets current_span
     def disjoint_spanned_method(self) -> None:
         """Do some things with a new disjoint span."""
         print("disjoint_spanned_method")
@@ -147,7 +160,10 @@ class ExternalClass:
     #         self.span.end()
 
 
-@wtt.spanned(attributes={"a": 1})  # auto end-on-exit
+@wtt.spanned(
+    span_namer=wtt.SpanNamer(use_function_name=False),
+    attributes={"a": 1},
+)  # auto end-on-exit
 def injected_span_pass_to_instance() -> ExternalClass:
     """Inject a span then pass onto an instance."""
     assert wtt.get_current_span().is_recording()

--- a/examples/wipac_tracing/span_client_server_http.py
+++ b/examples/wipac_tracing/span_client_server_http.py
@@ -22,7 +22,9 @@ PORT = 2000
 ########################################################################################
 
 
-@wtt.spanned(kind=wtt.SpanKind.CLIENT)
+@wtt.spanned(
+    span_namer=wtt.SpanNamer(literal_name="TheBestClient"), kind=wtt.SpanKind.CLIENT
+)
 def client() -> None:
     """Run HTTP client."""
     logging.info("Example HTTP Client with 'kind=SpanKind.CLIENT'")
@@ -66,7 +68,11 @@ def client() -> None:
 class HTTPRequestHandler(BaseHTTPRequestHandler):
     """Custom HTTPRequestHandler class."""
 
-    @wtt.spanned(kind=wtt.SpanKind.SERVER, carrier="self.headers")
+    @wtt.spanned(
+        span_namer=wtt.SpanNamer(use_this_arg="self.command"),
+        kind=wtt.SpanKind.SERVER,
+        carrier="self.headers",
+    )
     def do_GET(self) -> None:  # pylint: disable=invalid-name
         """Handle GET command."""
         logging.info("Example HTTP Server Handler with 'kind=SpanKind.SERVER'")

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -34,7 +34,7 @@ from .propagations import (  # noqa
     inject_span_carrier,
     span_to_link,
 )
-from .spans import CarrierRelation, SpanBehavior, respanned, spanned  # noqa
+from .spans import CarrierRelation, SpanBehavior, SpanNamer, respanned, spanned  # noqa
 
 __all__ = [
     "add_event",
@@ -51,6 +51,7 @@ __all__ = [
     "SpanBehavior",
     "SpanKind",
     "spanned",
+    "SpanNamer",
 ]
 
 

--- a/wipac_telemetry/tracing_tools/__init__.py
+++ b/wipac_telemetry/tracing_tools/__init__.py
@@ -57,7 +57,7 @@ __all__ = [
 # Config SDK ###########################################################################
 
 
-def _pseudo_log(msg: str) -> None:
+def _stderr_log(msg: str) -> None:
     print(f"[wipac-telemetry-setup] {msg}", file=sys.stderr)
 
 
@@ -80,7 +80,7 @@ def get_service_name() -> str:
 
     if package:
         # this means client is running as a module, so get the full package name + version
-        _pseudo_log(f"Detecting Service Name from `{package}`...")
+        _stderr_log(f"Detecting Service Name from `{package}`...")
         version = _get_version(package)
         service_name = f"{package} ({version})"
     else:
@@ -95,7 +95,7 @@ def get_service_name() -> str:
                 "this library before '__main__.py' was executed."
             ) from e
 
-        _pseudo_log(f"Detecting Service Name from `{main_mod_abspath}`...")
+        _stderr_log(f"Detecting Service Name from `{main_mod_abspath}`...")
         script = main_mod_abspath.name  # ex: 'myscript.py'
         with open(main_mod_abspath, "rb") as f:
             readable_hash = hashlib.sha256(f.read()).hexdigest()
@@ -103,15 +103,15 @@ def get_service_name() -> str:
 
     # check if user supplied a prefix
     if CONFIG["WIPACTEL_SERVICE_NAME_PREFIX"]:
-        _pseudo_log(f"with prefix: \"{CONFIG['WIPACTEL_SERVICE_NAME_PREFIX']}\"")
+        _stderr_log(f"with prefix: \"{CONFIG['WIPACTEL_SERVICE_NAME_PREFIX']}\"")
         service_name = f"{CONFIG['WIPACTEL_SERVICE_NAME_PREFIX']}/{service_name}"
 
-    _pseudo_log(f'Using Service Name: "{service_name}"')
+    _stderr_log(f'Using Service Name: "{service_name}"')
     return service_name
 
 
 if CONFIG["WIPACTEL_EXPORT_STDOUT"] or CONFIG["OTEL_EXPORTER_OTLP_ENDPOINT"]:
-    _pseudo_log("Setting Tracer Provider...")
+    _stderr_log("Setting Tracer Provider...")
     set_tracer_provider(
         TracerProvider(resource=Resource.create({SERVICE_NAME: get_service_name()}))
     )
@@ -120,14 +120,14 @@ else:
     set_tracer_provider(TracerProvider())
 
 if CONFIG["WIPACTEL_EXPORT_STDOUT"]:
-    _pseudo_log("Adding ConsoleSpanExporter")
+    _stderr_log("Adding ConsoleSpanExporter")
     get_tracer_provider().add_span_processor(
         # output to stdout
         SimpleSpanProcessor(ConsoleSpanExporter())
     )
 
 if CONFIG["OTEL_EXPORTER_OTLP_ENDPOINT"]:
-    _pseudo_log(f"Adding OTLPSpanExporter ({CONFIG['OTEL_EXPORTER_OTLP_ENDPOINT']})")
+    _stderr_log(f"Adding OTLPSpanExporter ({CONFIG['OTEL_EXPORTER_OTLP_ENDPOINT']})")
     get_tracer_provider().add_span_processor(
         # relies on env variables
         # -- https://opentelemetry-python.readthedocs.io/en/latest/exporter/otlp/otlp.html
@@ -147,4 +147,4 @@ if CONFIG["OTEL_EXPORTER_OTLP_ENDPOINT"]:
     )
 
 if CONFIG["WIPACTEL_EXPORT_STDOUT"] or CONFIG["OTEL_EXPORTER_OTLP_ENDPOINT"]:
-    _pseudo_log("Setup complete.")
+    _stderr_log("Setup complete.")


### PR DESCRIPTION
This will be helpful for the `RestHandler`. Currently, the span name is `"RestHandler._execute"` for REST requests. That's too vague for quick visual scanning of the UI. 

With this update, it can be: 
`"RestHandler._execute:GET"`, 
`"RestHandler._execute:POST"`, 
`"RestHandler._execute:rest-method"` (defeats this specific purpose, but it's possible),
`"RestHandler._execute:rest-method:POST"`, or even just 
`"REST:GET"`.